### PR TITLE
Moved destination and cache path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,6 @@ ENV/
 # Outputs
 /packages/
 /build/
+/cache/
 
 TODO

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# nbuild - Nest's Package Builder
+# Nest Build - Nest's Package Builder
 
-`nbuild` is Nest's package builder. It takes a `Build Manifest` (a python file) that describes the steps to be taken to build one or more packages, from retrieving the source files to achieving a fully built program.
+`Nest Build`, or `nbuild`, is [Nest](https://github.com/raven-os/nest)'s package builder. It takes a `Build Manifest` (a python file) that describes the steps to be taken to build one or more packages, from retrieving the source files to achieving a fully built program.
 
-Examples can be found in [nbuild-manifests](https://github.com/raven-os/nbuild-manifests).
+Examples can be found in the [nbuild-manifests](https://github.com/raven-os/nbuild-manifests) GitHub repository.
 
 `nbuild` places it's content in 4 seperate folders:
-    * `/usr/nbuild/downloads/`: All downloads are placed there so they can be re-used when rebuilding the same package
-    * `/usr/nbuild/sources/`: Packages are extracted and build there.
-    * `/usr/nbuild/installs/`: Packages are installed in this folder before being compressed
-    * `/usr/nbuild/packages`: The resulting package (`data.tar.gz` and `manifest.toml`) is placed there when the operation is successfully completed
+  * `./cache/downloads/`: All downloads are placed there so they can be re-used when rebuilding the same package
+  * `./cache/sources/`: Packages are extracted and build there.
+  * `./cache/installs/`: Packages are installed in this folder before being compressed
+  * `./packages/`: The resulting package (`data.tar.gz` and `manifest.toml`) is placed there when the operation is successfully completed.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ To install nbuild's dependencies, run
 pip install -r requirements.txt
 ```
 
-**Warning: Nest-build does NOT provide any kind of isolation**.
+**/!\Warning: Nest-build does NOT provide any kind of isolation /!\**
 
 If the manifest is ill-formed, your main system may be damaged. That's why we recommend the use of an isolation system like Docker.
 
@@ -41,13 +41,13 @@ from nbuild.stdenv.autotools import build_autotools_package
 
 
 @package(
-    id="stable::sys-lib/helloworld#1.0.0",
+    id='stable::sys-lib/helloworld#1.0.0',
 )
 def build_helloworld():
     build_autotools_package(
         fetch=lambda: fetch_url(
-            url=f"https://example.com/helloworld.tar.gz",
-            sha256="729e344a01e52c822bdfdec61e28d6eda02658d2e7d2b80a9b9029f41e212dde",
+            url='https://example.com/helloworld.tar.gz',
+            sha256='729e344a01e52c822bdfdec61e28d6eda02658d2e7d2b80a9b9029f41e212dde',
         ),
     )
 ```

--- a/nbuild/args.py
+++ b/nbuild/args.py
@@ -16,6 +16,18 @@ def parse_args():
         description='Compiles packages from a Build Manifest.'
     )
     nbuild_parser.add_argument(
+        '-o',
+        '--output-dir',
+        default='./packages/',
+        help='Output directory for built packages',
+    )
+    nbuild_parser.add_argument(
+        '-c',
+        '--cache-dir',
+        default='./cache/',
+        help='Cache directory used when downloading and building packages',
+    )
+    nbuild_parser.add_argument(
         'manifests',
         nargs='*'
     )

--- a/nbuild/stdenv/fetch.py
+++ b/nbuild/stdenv/fetch.py
@@ -35,7 +35,7 @@ def fetch_url(
     if not _check_file(path, md5, sha1, sha256):
         ilog(f"Fetching {url}")
         req = requests.get(url, stream=True)
-        with open(path, 'wb') as file:
+        with open(path, 'wb+') as file:
             for chunk in req.iter_content(chunk_size=4096):
                 file.write(chunk)
         clog(f"Fetch done. Stored at {path}")

--- a/nbuild/stdenv/fetch.py
+++ b/nbuild/stdenv/fetch.py
@@ -35,7 +35,7 @@ def fetch_url(
     if not _check_file(path, md5, sha1, sha256):
         ilog(f"Fetching {url}")
         req = requests.get(url, stream=True)
-        with open(path, 'wb+') as file:
+        with open(path, 'wb') as file:
             for chunk in req.iter_content(chunk_size=4096):
                 file.write(chunk)
         clog(f"Fetch done. Stored at {path}")

--- a/nbuild/stdenv/package.py
+++ b/nbuild/stdenv/package.py
@@ -34,10 +34,13 @@ class Package():
             self.version,
         )
 
-        self.download_dir = os.path.join('/usr/nbuild/downloads/', dir)
-        self.source_dir = os.path.join('/usr/nbuild/sources/', dir)
-        self.install_dir = os.path.join('/usr/nbuild/installs/', dir)
-        self.package_dir = os.path.join('/usr/nbuild/packages/', dir)
+        cwd = os.getcwd()
+        cache_dir = get_args().cache_dir
+        output_dir = get_args().output_dir
+        self.download_dir = os.path.join(cwd, cache_dir, 'downloads/', dir)
+        self.source_dir = os.path.join(cwd, cache_dir, 'sources/', dir)
+        self.install_dir = os.path.join(cwd, cache_dir, 'installs/', dir)
+        self.package_dir = os.path.join(cwd, output_dir, dir)
 
         # Erase old content of previous builds
         if os.path.exists(self.source_dir):


### PR DESCRIPTION
The old path was `/usr/nbuild`, which is supposed to be read-only.

This commit makes the destination and cache path relative to the
current directory.

Hence, instead of having `/usr/nbuild/{downloads,installs,sources}/`, we have `./cache/{downloads,installs, sources}/`, and instead of having `/usr/nbuild/packages/` we have `./packages/`.