### PR TITLE
stdlib/prelude

### DIFF
--- a/nbuild/__init__.py
+++ b/nbuild/__init__.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3.6
-# -*- coding: utf-8 -*-
-
-pass
+from nbuild.stdenv.autotools.make import do_make
+from nbuild.stdenv.autotools.autoconf import do_configure
+from nbuild.stdenv.autotools import build_autotools_package
+from nbuild.stdenv.install import exclude_dirs, keep_only
+from nbuild.stdenv.package import package
+from nbuild.stdenv.build import current_build
+from nbuild.stdenv.fetch import fetch_urls

--- a/nbuild/__init__.py
+++ b/nbuild/__init__.py
@@ -1,7 +1,9 @@
-from nbuild.stdenv.autotools.make import do_make
-from nbuild.stdenv.autotools.autoconf import do_configure
+from nbuild.cmd import cmd
+from nbuild.pushd import pushd
 from nbuild.stdenv.autotools import build_autotools_package
+from nbuild.stdenv.autotools.autoconf import do_configure
+from nbuild.stdenv.autotools.make import do_make
+from nbuild.stdenv.build import current_build
+from nbuild.stdenv.fetch import fetch_url, fetch_urls
 from nbuild.stdenv.install import exclude_dirs, keep_only
 from nbuild.stdenv.package import package
-from nbuild.stdenv.build import current_build
-from nbuild.stdenv.fetch import fetch_urls

--- a/nbuild/cmd.py
+++ b/nbuild/cmd.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 from copy import deepcopy
 from textwrap import dedent
-from nbuild.args import nbuild_args
+from nbuild.args import get_args
 from nbuild.log import ilog, dlog, flog
 
 
@@ -20,7 +20,7 @@ def cmd(
 
     This is nothing more than a wrapper to reduce boilerplate.
     """
-    global nbuild_args
+    nbuild_args = get_args()
 
     cmd = dedent(cmd)
     new_env = deepcopy(os.environ)


### PR DESCRIPTION
This is of course subject to be modified if/when new features are added to nbuild

[This](https://github.com/raven-os/nbuild-manifests/compare/ncurses...melis-m:ncurses) shows an example of a diff between a manifest using, and a one not using, this prelude.