### PR TITLE
New triplet

### DIFF
--- a/nbuild/stdenv/autotools/__init__.py
+++ b/nbuild/stdenv/autotools/__init__.py
@@ -4,10 +4,11 @@
 import os
 from nbuild.log import ilog
 from nbuild.pushd import pushd
+from nbuild.stdenv.patch import apply_patches
 from nbuild.stdenv.build import current_build
 from nbuild.stdenv.extract import extract_tarballs
 from nbuild.stdenv.autotools.make import do_make
-from nbuild.stdenv.patch import apply_patches
+from nbuild.stdenv.install import exclude_dirs, keep_only
 from nbuild.stdenv.autotools.autoconf import do_configure
 
 

--- a/nbuild/stdenv/package.py
+++ b/nbuild/stdenv/package.py
@@ -153,7 +153,7 @@ class Package():
         ilog(f"Output placed in {self.package_dir}")
 
 
-def package(id: str, description, build_dependencies={}, run_dependencies={}):
+def package(id: str, description: str, build_dependencies={}, run_dependencies={}):
 
     def register_package(builder):
         package = Package(id, description, builder, run_dependencies)

--- a/nbuild/stdenv/package.py
+++ b/nbuild/stdenv/package.py
@@ -75,8 +75,8 @@ class Package():
 
             # Target & host architecture
             # TODO FIXME Set as parameter
-            os.environ['TARGET'] = 'x86_64-pc-linux-gnu'
-            os.environ['HOST'] = 'x86_64-pc-linux-gnu'
+            os.environ['TARGET'] = 'x86_64-linux-gnu'
+            os.environ['HOST'] = 'x86_64-linux-gnu'
 
             # Common flags for the gnu toolchain (cpp, cc, cxx, as, ld)
             gnuflags = '-O -s -m64 -mtune=generic'


### PR DESCRIPTION
The new triplet is the default one on ubuntu/debian, which is the most popular Linux distribution out there.

It makes more sense to use their default instead of an other one, as we'll be compatible with more users.
Of course, all of this matters until *we* choose our triplet, but it's very likely it'll be the same than the Debian one.

So yeah, here we are.