### PR TITLE
Add `stdlib.manifest`, `stdlib.build` and `stdlib.package`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ dmypy.json
 /docs/source/core*.rst
 /docs/source/nbuild*.rst
 /docs/source/stdlib*.rst
+/docs/source/modules.rst

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3.6
 # -*- coding: utf-8 -*-
-
 """Core modules used exclusively by :py:mod:`nbuild` or the compilation library (:py:mod:`stdlib`).
 
 The content of the core module should not be used by a build manifest.
 """
-
-import core.args
-import core.cache

--- a/core/args.py
+++ b/core/args.py
@@ -71,8 +71,8 @@ def parse_args():
 def get_args():
     """Return an object holding the values of each command line argument.
 
-    This function relays the return value of :py:func:`argparse.ArgumentParser.parse_args()`, so refer to :py:mod:`argparse`'s documentation
-    for its exact behaviour.
+    :returns: The return value of :py:func:`argparse.ArgumentParser.parse_args()`, so refer to :py:mod:`argparse`'s
+        documentation for its exact content and behaviour.
     """
     return nbuild_args
 

--- a/core/cache.py
+++ b/core/cache.py
@@ -8,65 +8,73 @@ import os
 import sys
 import shutil
 import random
-import stdlib
-from core.args import get_args
+import core.args
+import stdlib.build
 
 
-def get_install_cache(build: stdlib.Build) -> str:
+def get_install_cache(build) -> str:
     """Get the path pointing to the cache where the files produced by the given build should be stored.
 
     :info: The content of this cache mimics a Linux file system
     :param build: The build associated with the cache
+    :type build: :py:class:`.Build`
+
     :returns: The path pointing to the cache where the produced files should be stored
     """
     return os.path.join(
-        get_args().cache_dir,
+        core.args.get_args().cache_dir,
         'install',
-        build.manifest.name,
+        build.manifest.metadata.name,
         build.semver,
     )
 
 
-def get_download_cache(build: stdlib.Build) -> str:
+def get_download_cache(build) -> str:
     """Get the path pointing to the cache where the files downloaded by the given build should be stored.
 
     :info: This cache is kept across builds to avoid downloading the same files over and over
     :param build: The build associated with the cache
+    :type build: :py:class:`.Build`
+
     :returns: The path pointing to the cache where the downloaded files should be stored
     """
     return os.path.join(
-        get_args().cache_dir,
+        core.args.get_args().cache_dir,
         'download',
-        build.manifest.name,
+        build.manifest.metadata.name,
         build.semver,
     )
 
 
-def get_build_cache(build: stdlib.Build) -> str:
+def get_build_cache(build) -> str:
     """Get the path pointing to the cache where the given build should be built.
 
     :param build: The build associated with the cache
+    :type build: :py:class:`.Build`
+
     :returns: The path pointing to the cache where the build is built
     """
     return os.path.join(
-        get_args().cache_dir,
+        core.args.get_args().cache_dir,
         'build',
-        build.manifest.name,
+        build.manifest.metadata.name,
         build.semver,
     )
 
 
-def get_wrap_cache(package: stdlib.Package) -> str:
+def get_wrap_cache(package) -> str:
     """Get the path pointing to the cache where the files belonging to the given package should be stored.
 
     When the build is over, all files in the cache will be wrapped to form the package's content.
 
     :info: The content of this cache mimics a Linux file system
     :param package: The package associated with the cache
+    :type package: :py:class:`.Package`
+
     :returns: The path pointing to the cache where the files belonging to the given package should be stored
     """
     return os.path.join(
-        get_args().cache_dir,
+        core.args.get_args().cache_dir,
         'wrap',
         package.id.repository,
         package.id.category,
@@ -75,17 +83,19 @@ def get_wrap_cache(package: stdlib.Package) -> str:
     )
 
 
-def get_package_cache(package: stdlib.Package) -> str:
+def get_package_cache(package) -> str:
     """Get the path pointing to the cache where the final package, at the very end of the build process, should be stored.
 
     This cache is populated automatically at the end of the build process. A build manifest should not have to write anything to it.
 
     :info: This cache is populated by Package.wrap() and contains the manifest and data of the package
     :param package: The package associated with the cache
+    :type package: :py:class:`.Package`
+
     :returns: The path pointing to the cache where the files belonging to the given package should be stored
     """
     return os.path.join(
-        get_args().output_dir,
+        core.args.get_args().output_dir,
         package.id.repository,
         package.id.category,
         package.id.name,
@@ -95,7 +105,7 @@ def get_package_cache(package: stdlib.Package) -> str:
 
 def purge_cache():
     """Purge the content of the `wrap`, `build`, `download` and `install` cache for all builds."""
-    folder = get_args().cache_dir
+    folder = core.args.get_args().cache_dir
 
     for file in os.listdir(folder):
         path = os.path.join(folder, file)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_autodoc_typehints
+sphinx_rtd_theme

--- a/nbuild.py
+++ b/nbuild.py
@@ -5,8 +5,8 @@
 import os
 import re
 import importlib.util
-import core
-import stdlib
+import core.args
+import stdlib.log
 from dotenv import load_dotenv
 from multiprocessing import cpu_count
 
@@ -17,9 +17,9 @@ def main():
     if core.args.get_args().purge:
         from core.cache import purge_cache
 
-        print("Purging cache... ", end='')
+        stdlib.log.ilog("Purging caches... ")
         purge_cache()
-        print("Done!")
+        stdlib.log.slog("Caches purged!")
         exit(0)
 
     if core.args.get_args().manifest is None:

--- a/stdlib/__init__.py
+++ b/stdlib/__init__.py
@@ -3,15 +3,6 @@
 """The standard compilation library used by all build manifests."""
 
 # Prelude
-from stdlib.build import Build
-from stdlib.package import Package
 from stdlib.license import License
 from stdlib.pushd import pushd
 from stdlib.pushenv import pushenv
-
-import stdlib.build
-import stdlib.package
-import stdlib.log
-import stdlib.license
-import stdlib.pushd
-import stdlib.pushenv

--- a/stdlib/build.py
+++ b/stdlib/build.py
@@ -60,6 +60,7 @@ class Build():
         os.makedirs(self.install_cache)
 
         # Call the parent's manifest instructions
+        os.chdir(self.build_cache)
         return self.manifest.instructions(self)
 
 

--- a/stdlib/build.py
+++ b/stdlib/build.py
@@ -59,7 +59,7 @@ class Build():
             shutil.rmtree(self.install_cache)
         os.makedirs(self.install_cache)
 
-        # Call the parent's manifest instrutions
+        # Call the parent's manifest instructions
         return self.manifest.instructions(self)
 
 

--- a/stdlib/build.py
+++ b/stdlib/build.py
@@ -6,7 +6,7 @@
 
 import os
 import shutil
-from typing import Dict
+from typing import Dict, Iterable
 
 _current_build = None
 
@@ -29,7 +29,7 @@ class Build():
         self.args = args
 
         self.semver = self.args['semver']
-        (self.major, self.minor, self.patch) = self.args['semver'].split('.')
+        self.major, self.minor, self.patch = self.args['semver'].split('.')
 
         from core.cache import get_download_cache, get_build_cache, get_install_cache
         self.download_cache = get_download_cache(self)
@@ -42,9 +42,9 @@ class Build():
     def build(self):
         """Set the current build to ``self`` and execute the instructions contained in the :py:class:`.BuildManifest`.
 
-        :returns: An iterator over a list of :py:class:`.Package` s.
+        :returns: An iterable collection of :py:class:`.Package` s, like a ``List``.
             It forwards the return value of the instructions contained in the :py:class:`.BuildManifest`.
-        :returntype: ``List`` [ :py:class:`.Package` ]
+        :returntype: ``Iterable`` [ :py:class:`.Package` ]
         """
         _set_current_build(self)
 

--- a/stdlib/build.py
+++ b/stdlib/build.py
@@ -1,8 +1,79 @@
 #!/usr/bin/env python3.6
 # -*- coding: utf-8 -*-
+"""Types and functions to create and manipulate a :py:class:`.Build`, an instance of a
+:py:class:`.BuildManifest` for a specific version.
+"""
 
-import stdlib
+import os
+import shutil
+from typing import Dict
+
+_current_build = None
 
 
 class Build():
-    pass
+    """An instance of a :py:class:`.BuildManifest` for a specific version.
+
+    :param manifest: The :py:class:`.BuildManifest` this :py:class:`.Build` belongs to.
+    :type manifest: :py:class:`~.BuildManifest`
+
+    :param args: The arguments of this build. This is a subset of ``BuildManifest.versionized_args``,
+        the one corresponding to the version of this build.
+    """
+    def __init__(
+        self,
+        manifest,
+        args: Dict[str, str],
+    ):
+        self.manifest = manifest
+        self.args = args
+
+        self.semver = self.args['semver']
+        (self.major, self.minor, self.patch) = self.args['semver'].split('.')
+
+        from core.cache import get_download_cache, get_build_cache, get_install_cache
+        self.download_cache = get_download_cache(self)
+        self.build_cache = get_build_cache(self)
+        self.install_cache = get_install_cache(self)
+
+    def __str__(self):
+        return f'''{self.manifest.metadata.name} ({self.semver})'''
+
+    def build(self):
+        """Set the current build to ``self`` and execute the instructions contained in the :py:class:`.BuildManifest`.
+
+        :returns: An iterator over a list of :py:class:`.Package` s.
+            It forwards the return value of the instructions contained in the :py:class:`.BuildManifest`.
+        :returntype: ``List`` [ :py:class:`.Package` ]
+        """
+        _set_current_build(self)
+
+        # Create the caches
+        os.makedirs(self.download_cache, exist_ok=True)
+
+        if os.path.exists(self.build_cache):
+            shutil.rmtree(self.build_cache)
+        os.makedirs(self.build_cache)
+
+        if os.path.exists(self.install_cache):
+            shutil.rmtree(self.install_cache)
+        os.makedirs(self.install_cache)
+
+        # Call the parent's manifest instrutions
+        return self.manifest.instructions(self)
+
+
+def current_build() -> Build:
+    """Return the :py:class:`.Build` currently being executed.
+
+    :info: This function is mainly used by the :py:mod:`stdlib` functions to avoid explictly taking
+        the current :py:class:`.Build` as a parameter.
+    :returns: The :py:class:`.Build` currently being executed.
+    """
+    global _current_build
+    return _current_build
+
+
+def _set_current_build(build: Build):
+    global _current_build
+    _current_build = build

--- a/stdlib/license.py
+++ b/stdlib/license.py
@@ -23,4 +23,4 @@ class License(Enum):
     PUBLIC_DOMAIN = 'Public Domain'
 
     CUSTOM = 'Custom'
-    NONE = 'None',
+    NONE = 'None'

--- a/stdlib/log.py
+++ b/stdlib/log.py
@@ -23,8 +23,8 @@ def pushlog():
         log_tab_level -= 1
 
 
-def dlog(*logs):
-    """Print a debug log, prefixed by a magenta `[d]`.
+def dlog(*logs: str):
+    """Print a debug log, prefixed by a magenta ``[d]``.
 
     :param logs: The content of the log.
     """
@@ -34,8 +34,8 @@ def dlog(*logs):
     print(f"{termcolor.colored('[d]', 'magenta', attrs=['bold'])} {indent}", *logs)
 
 
-def ilog(*logs):
-    """Print an informative log, prefixed by a blue `[*]`.
+def ilog(*logs: str):
+    """Print an informative log, prefixed by a blue ``[*]``.
 
     :param logs: The content of the log.
     """
@@ -45,19 +45,19 @@ def ilog(*logs):
     print(f"{termcolor.colored('[*]', 'blue', attrs=['bold'])} {indent}", *logs)
 
 
-def slog(*args):
-    """Print a success log, prefixed by a green `[+]`.
+def slog(*logs: str):
+    """Print a success log, prefixed by a green ``[+]``.
 
     :param logs: The content of the log.
     """
     global log_tab_level
 
     indent = '\t' * log_tab_level
-    print(f"{termcolor.colored('[+]', 'green', attrs=['bold'])} {indent}", *args)
+    print(f"{termcolor.colored('[+]', 'green', attrs=['bold'])} {indent}", *logs)
 
 
-def wlog(*logs):
-    """Print a warning log, prefixed by a yellow `[!]`.
+def wlog(*logs: str):
+    """Print a warning log, prefixed by a yellow ``[!]``.
 
     :param logs: The content of the log.
     """
@@ -67,8 +67,8 @@ def wlog(*logs):
     print(f"{termcolor.colored('[!]', 'yellow', attrs=['bold'])} {indent}", *logs)
 
 
-def elog(*logs):
-    """Print a non-fatal error log, prefixed by a red `[-]`.
+def elog(*logs: str):
+    """Print a non-fatal error log, prefixed by a red ``[-]``.
 
     :param logs: The content of the log.
     """
@@ -78,10 +78,10 @@ def elog(*logs):
     print(f"{termcolor.colored('[-]', 'red', attrs=['bold'])} {indent}", *logs)
 
 
-def flog(logs):
-    """Print a fatal error log, all in red, prefixed by `[-]`.
+def flog(*logs: str):
+    """Print a fatal error log, all in red, prefixed by ``[-]``.
 
     :info: This function does NOT abort the current process's execution.
     :param logs: The content of the log.
     """
-    termcolor.cprint(f"[-] {logs}", 'red', attrs=['bold'])
+    termcolor.cprint(f"[-]  {' '.join(logs)}", 'red', attrs=['bold'])

--- a/stdlib/manifest.py
+++ b/stdlib/manifest.py
@@ -12,8 +12,8 @@ It is typically made of three main parts:
 The build manifest can then generate a list of :py:class:`.Build` for each version in the versionized arguments.
 Those :py:class:`.Build` s will take as parameter (among other things) the set of data associated with this version.
 
-For example, it may have a field named ``url`` holding an URL pointing to the source code of the software.
-Therefore, this field will hold the correct URL for all versions and is easily accessible in a uniform, version-independant way.
+For example, it may have a field named ``url`` holding a URL pointing to the source code of the software.
+Therefore, this field will hold the correct URL for all versions and is easily accessible in a uniform, version-independent way.
 
 *Example of an illustrated versionized list of arguments:*
 
@@ -37,10 +37,10 @@ from typing import List, Dict
 class BuildManifestMetadata():
     """A set of values used as a reference when filling the metadata of the built packages
 
-    Built packages will reuse these information to build their own metadata.
-    For example, the developper version of a package might reuse the name provided and append ``-dev`` at the end.
+    Built packages will reuse this information to build their own metadata.
+    For example, the developer version of a package might reuse the name provided and append ``-dev`` at the end.
 
-    :info: The information provided here can be overriden on a package-per-package basis. They are only here as a default option.
+    :info: The information provided here can be overriden on a per-package basis. They are only here as a default option.
 
     :param name: The name of the software being built. The name should be in ``snake-case``.
     :param category: The category the built packages belong to. The category should be in ``snake-case``.
@@ -141,8 +141,8 @@ class BuildManifest():
     :param versionized_args: A list of dictionaries used as a generic way to give arguments to each versions of the build.
         See the above explanations for its exact structure and limitations.
     :param instructions: A callable (usually a python function) that builds the packages. It takes a :py:class:`~stdlib.build.Build` as parameter
-        and returns an iterator over a list of :py:class:`~stdlib.package.Package` (usually a list).
-    :type instructions: fn (:py:class:`~stdlib.build.Build`) -> List[:py:class:`~stdlib.package.Package`]
+        and returns an iterable collection of :py:class:`~stdlib.package.Package` (usually a list).
+    :type instructions: fn (:py:class:`~stdlib.build.Build`) -> ``Iterable`` [ :py:class:`~stdlib.package.Package` ]
 
     :ivar metadata: A set of values used as a reference when filling the metadata of the built packages
     :vartype metadata: :py:class:`~BuildManifestMetadata`
@@ -151,7 +151,7 @@ class BuildManifest():
     :vartype versionized_args: ``List`` [ ``Dict`` [ ``str``, ``str`` ] ]
 
     :ivar instructions: A callable that builds the package.
-    :vartype instructions: fn (:py:class:`~stdlib.build.Build`) -> List[:py:class:`~stdlib.package.Package`]
+    :vartype instructions: fn (:py:class:`~stdlib.build.Build`) -> ``Iterable`` [ :py:class:`~stdlib.package.Package` ]
     """
     def __init__(
         self,
@@ -166,14 +166,14 @@ class BuildManifest():
     def builds(self):
         """Aggregate all the builds for this manifest into a list, one per version.
 
-        :returns: A lit of all the builds for this manifest, one per version.
+        :returns: A list of all the builds for this manifest, one per version.
         :returntype: ``List`` [ :py:class:`.Build` ]
         """
         from stdlib.build import Build
-        return map(
+        return list(map(
             lambda args: Build(self, args),
             self.versionized_args,
-        )
+        ))
 
 
 def manifest(
@@ -189,7 +189,7 @@ def manifest(
     created and executed (using :py:func:`stdlib.build.Build.build`).
     At the end, all the retrieved packages are wrapped using :py:func:`stdlib.package.Package.wrap`.
 
-    :info: The environment and current working directory is saved before each build, limiting the impact of one build on an other.
+    :info: The environment and current working directory are saved before each build, limiting the impact of one build on another.
     :info: See the constructor of :py:class:`~stdlib.manifest.BuildManifest` and :py:class:`.BuildManifestMetadata`
         for the exact meaning and limitation of ``kwargs`` and ``versions_data``.
     :info: The packages ``stable::raven-os/essentials`` and ``stable::raven-os/essentials-dev`` are guaranteed to be installed.

--- a/stdlib/manifest.py
+++ b/stdlib/manifest.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+"""Provides types and functions to create and manipulate a build manifest and all its components.
+
+A build manifest is a set of instructions that fetches, compiles, and splits a software into one or more packages.
+It is typically made of three main parts:
+
+  * A set of metadata used as a reference for the metadata of the built packages
+  * A list of versions and a corresponding set of data, one per version, called the versionized arguments of a build
+  * A list of instructions (taking the form of a python function) that builds the packages
+
+The build manifest can then generate a list of :py:class:`.Build` for each version in the versionized arguments.
+Those :py:class:`.Build` s will take as parameter (among other things) the set of data associated with this version.
+
+For example, it may have a field named ``url`` holding an URL pointing to the source code of the software.
+Therefore, this field will hold the correct URL for all versions and is easily accessible in a uniform, version-independant way.
+
+*Exemple of an illustrated versionized list of arguments:*
+
++---------+-----------------------------------------------+----------------------------------------------+
+| Version | Value of the field ``url``                    | Value of the field ``sha256``                |
++=========+===============================================+==============================================+
+| 1.0.0   | ``https://example.com/software_1.0.0.tar.gz`` | ``5891b5b522d5df086d0ff0b110fbd9d21bb4f...`` |
++---------+-----------------------------------------------+----------------------------------------------+
+| 1.1.0   | ``https://example.com/software_1.1.0.tar.gz`` | ``e258d248fda94c63753607f7c4494ee0fcbe9...`` |
++---------+-----------------------------------------------+----------------------------------------------+
+| 1.2.0   | ``https://example.com/software_1.2.0.tar.gz`` | ``fc7c46367a4ef38398cdfd30b56885357e86b...`` |
++---------+-----------------------------------------------+----------------------------------------------+
+"""
+
+import os
+import core
+import stdlib.log
+from typing import List, Dict
+
+
+class BuildManifestMetadata():
+    """A set of values used as a reference when filling the metadata of the built packages
+
+    Built packages will reuse these information to build their own metadata.
+    For example, the developper version of a package might reuse the name provided and append ``-dev`` at the end.
+
+    :info: The information provided here can be overriden on a package-per-package basis. They are only here as a default option.
+
+    :param name: The name of the software being built. The name should be in ``snake-case``.
+    :param category: The category the built packages belong to. The category should be in ``snake-case``.
+    :param description: A description of the software being built. This description should start with an uppercase letter and finish with a dot.
+    :param tags: A list of tags helping a user find the built packages easily. Each tag should be in ``snake-case``.
+    :param maintainer: The email address of the maintainer of this build manifest.
+    :param licenses: The licenses of the built software.
+    :type licenses: ``List`` [ :py:class:`.License` ]
+    :param upstream_url: The URL pointing to the home page of the software.
+
+    :ivar name: The name of the software being built.
+    :vartype name: ``str``
+
+    :ivar category: The category the built packages belong to.
+    :vartype category: ``str``
+
+    :ivar description: A description of the software being built.
+    :vartype description: ``str``
+
+    :ivar tags: A list of tags helping a user find the built packages easily.
+    :vartype tags: ``List`` [ ``str`` ]
+
+    :ivar maintainer: The email address of the maintainer of this build manifest.
+    :vartype maintainer: ``str``
+
+    :ivar licenses: The licenses of the built software.
+    :vartype licenses: ``List`` [ :py:class:`~stdlib.license.License` ]
+
+    :ivar upstream_url: The URL pointing to the home page of the software.
+    :vartype upstream_url: ``str``
+    """
+    def __init__(
+        self,
+        name: str,
+        category: str,
+        description: str,
+        tags: List[str],
+        maintainer: str,
+        licenses,
+        upstream_url: str,
+    ):
+        self.name = name
+        self.category = category
+        self.description = description.replace('\n', ' ').strip()
+        self.tags = tags
+        self.maintainer = maintainer
+        self.licenses = licenses
+        self.upstream_url = upstream_url
+
+
+class BuildManifest():
+    """A build manifest is a set of instructions that fetches, compiles, and splits a software into one or more packages.
+
+    It is made of three components:
+
+      * A set of metadata used as a reference for the metadata of the built packages
+      * A list of versions and a corresponding set of data, one per version, called the versionized arguments of a build
+      * A list of instructions (taking the form of a python function) that builds the packages
+
+    **Versionized Arguments:**
+
+    The field ``versionized_args`` is a list. Each entry in this list represents a new version of the software.
+    The entries are a dictionnary holding the build's arguments for each version.
+
+    It must have a key named ``semver`` that holds the version number, following `Semantic Versioning 2.0.0`_.
+
+    All the remaining pairs of key/value can be used freely. Some functions of the standard compilation library (:py:mod:`stdlib`)
+    may use them as generic, version-agnostic arguments. To ensure future compatibility, the standard compilation library reserves
+    all key names that doesn't start with an underscore (``_``).
+
+    For example, the function :py:func:`stdlib.fetch.fetch_data` is used to download files (like the source code) before building a software.
+    It looks for an entry named ``fetch_url`` in ``versionized_args`` that contains the elements needed to download a file (its URL, its hash etc.)
+    (See the documentation of :py:func:`stdlib.fetch.fetch_data` for more informations.)
+
+    Here is an exemple of ``versionized_args`` for a build manifest supporting two versions (``1.0.0`` and ``1.1.0``) of the software
+    and uses the function :py:func:`stdlib.fetch.fetch_data` to download the source code::
+
+        [
+            {
+                'semver': '1.0.0',
+                'fetch_url': {
+                    'url': 'http://example.com/dl/hello_world_1.0.0.tar.gz',
+                    'sha256': '5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03',
+                },
+            },
+            {
+                'semver': '1.1.0',
+                'fetch_url': {
+                    'url': 'http://example.com/dl/hello_world_1.1.0.tar.gz',
+                    'sha256': 'e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317',
+                },
+            }
+        ]
+
+    .. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
+
+    :param metadata: A set of values used as a reference when filling the metadata of the built packages
+    :param versionized_args: A list of dictionnaries used as a generic way to give arguments for each versions of the build.
+        See the above explanations for its exact structure and limitations.
+    :param instructions: A callable (usually a python function) that builds the packages. It takes a :py:class:`~stdlib.build.Build` as parameter
+        and returns an iterator over a list of :py:class:`~stdlib.package.Package` (usually a list).
+    :type instructions: fn (:py:class:`~stdlib.build.Build`) -> List[:py:class:`~stdlib.package.Package`]
+
+    :ivar metadata: A set of values used as a reference when filling the metadata of the built packages
+    :vartype metadata: :py:class:`~BuildManifestMetadata`
+
+    :ivar versionized_args: A list of dictionnaries used as a generic way to give arguments for each versions of the build.
+    :vartype versionized_args: ``List`` [ ``Dict`` [ ``str``, ``str`` ] ]
+
+    :ivar instructions: A callable that builds the package.
+    :vartype instructions: fn (:py:class:`~stdlib.build.Build`) -> List[:py:class:`~stdlib.package.Package`]
+    """
+    def __init__(
+        self,
+        metadata: BuildManifestMetadata,
+        versionized_args: List[Dict[str, str]],
+        instructions,
+    ):
+        self.metadata = metadata
+        self.versionized_args = versionized_args
+        self.instructions = instructions
+
+    def builds(self):
+        """Aggregate all the builds for this manifest into a list, one per version.
+
+        :returns: A lit of all the builds for this manifest, one per version.
+        :returntype: ``List`` [ :py:class:`.Build` ]
+        """
+        from stdlib.build import Build
+        return map(
+            lambda args: Build(self, args),
+            self.versionized_args,
+        )
+
+
+def manifest(
+    versions_data: List[Dict[str, str]],
+    build_dependencies: List[str] = [],
+    **kwargs,
+):
+    """Create a :py:class:`.BuildManifest` and executes all the builds generated.
+
+    First, this function will create an instance of :py:class:`.BuildManifest` with the given metadata.
+    Then it will install the build dependencies needed to compile the software.
+    For all versions in the build manifest, a :py:class:`.Build` instance is
+    created and executed (using :py:func:`stdlib.build.Build.build`).
+    At the end, all the retrieved packets are wrapped using :py:func:`stdlib.package.Package.wrap`.
+
+    :info: The environment and current working directory is saved before each build, limiting the impact of one build on an other.
+    :info: See the constructor of :py:class:`~stdlib.manifest.BuildManifest` and :py:class:`.BuildManifestMetadata`
+        for the exact meaning and limitation of ``kwargs`` and ``versions_data``.
+    :info: The packages ``stable::raven-os/essentials`` and ``stable::raven-os/essentials-dev`` are guaranteed to be installed.
+        There is no need to include them in ``build_dependencies``.
+
+    :param kwargs: Arguments transfered to the constructor of :py:class:`.BuildManifestMetadata`
+    :param versions_data: Versionized arguments of the build manifest.
+    :param build_dependencies: A list of package requirements that must be installed (using ``nest``) before building anything.
+    """
+    def exec_manifest(builder):
+        metadata = BuildManifestMetadata(**kwargs)
+        manifest = BuildManifest(metadata, versions_data, builder)
+
+        # Install build dependencies
+        for build_dep in build_dependencies:
+            stdlib.log.slog(f"Installing build dependency \"{build_dep}\"")
+
+        for build in manifest.builds():
+            stdlib.log.slog(f"Building {build}")
+
+            # Save state before building
+            with stdlib.pushd(), stdlib.pushenv(), stdlib.log.pushlog():
+                pkgs = build.build()
+
+                # Wrap packages
+                for pkg in pkgs:
+                    pkg.wrap()
+
+    return exec_manifest

--- a/stdlib/manifest.py
+++ b/stdlib/manifest.py
@@ -15,7 +15,7 @@ Those :py:class:`.Build` s will take as parameter (among other things) the set o
 For example, it may have a field named ``url`` holding an URL pointing to the source code of the software.
 Therefore, this field will hold the correct URL for all versions and is easily accessible in a uniform, version-independant way.
 
-*Exemple of an illustrated versionized list of arguments:*
+*Example of an illustrated versionized list of arguments:*
 
 +---------+-----------------------------------------------+----------------------------------------------+
 | Version | Value of the field ``url``                    | Value of the field ``sha256``                |
@@ -45,7 +45,7 @@ class BuildManifestMetadata():
     :param name: The name of the software being built. The name should be in ``snake-case``.
     :param category: The category the built packages belong to. The category should be in ``snake-case``.
     :param description: A description of the software being built. This description should start with an uppercase letter and finish with a dot.
-    :param tags: A list of tags helping a user find the built packages easily. Each tag should be in ``snake-case``.
+    :param tags: A list of tags helping a user to find the built packages easily. Each tag should be in ``snake-case``.
     :param maintainer: The email address of the maintainer of this build manifest.
     :param licenses: The licenses of the built software.
     :type licenses: ``List`` [ :py:class:`.License` ]
@@ -60,7 +60,7 @@ class BuildManifestMetadata():
     :ivar description: A description of the software being built.
     :vartype description: ``str``
 
-    :ivar tags: A list of tags helping a user find the built packages easily.
+    :ivar tags: A list of tags helping a user to find the built packages easily.
     :vartype tags: ``List`` [ ``str`` ]
 
     :ivar maintainer: The email address of the maintainer of this build manifest.
@@ -103,19 +103,19 @@ class BuildManifest():
     **Versionized Arguments:**
 
     The field ``versionized_args`` is a list. Each entry in this list represents a new version of the software.
-    The entries are a dictionnary holding the build's arguments for each version.
+    The entries are a dictionary holding the build's arguments for each version.
 
     It must have a key named ``semver`` that holds the version number, following `Semantic Versioning 2.0.0`_.
 
     All the remaining pairs of key/value can be used freely. Some functions of the standard compilation library (:py:mod:`stdlib`)
     may use them as generic, version-agnostic arguments. To ensure future compatibility, the standard compilation library reserves
-    all key names that doesn't start with an underscore (``_``).
+    all key names that don't start with an underscore (``_``).
 
     For example, the function :py:func:`stdlib.fetch.fetch_data` is used to download files (like the source code) before building a software.
     It looks for an entry named ``fetch_url`` in ``versionized_args`` that contains the elements needed to download a file (its URL, its hash etc.)
     (See the documentation of :py:func:`stdlib.fetch.fetch_data` for more informations.)
 
-    Here is an exemple of ``versionized_args`` for a build manifest supporting two versions (``1.0.0`` and ``1.1.0``) of the software
+    Here is an example of ``versionized_args`` for a build manifest supporting two versions (``1.0.0`` and ``1.1.0``) of the software
     and uses the function :py:func:`stdlib.fetch.fetch_data` to download the source code::
 
         [
@@ -138,7 +138,7 @@ class BuildManifest():
     .. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
 
     :param metadata: A set of values used as a reference when filling the metadata of the built packages
-    :param versionized_args: A list of dictionnaries used as a generic way to give arguments for each versions of the build.
+    :param versionized_args: A list of dictionaries used as a generic way to give arguments to each versions of the build.
         See the above explanations for its exact structure and limitations.
     :param instructions: A callable (usually a python function) that builds the packages. It takes a :py:class:`~stdlib.build.Build` as parameter
         and returns an iterator over a list of :py:class:`~stdlib.package.Package` (usually a list).
@@ -147,7 +147,7 @@ class BuildManifest():
     :ivar metadata: A set of values used as a reference when filling the metadata of the built packages
     :vartype metadata: :py:class:`~BuildManifestMetadata`
 
-    :ivar versionized_args: A list of dictionnaries used as a generic way to give arguments for each versions of the build.
+    :ivar versionized_args: A list of dictionaries used as a generic way to give arguments to each versions of the build.
     :vartype versionized_args: ``List`` [ ``Dict`` [ ``str``, ``str`` ] ]
 
     :ivar instructions: A callable that builds the package.
@@ -181,13 +181,13 @@ def manifest(
     build_dependencies: List[str] = [],
     **kwargs,
 ):
-    """Create a :py:class:`.BuildManifest` and executes all the builds generated.
+    """Create a :py:class:`.BuildManifest` and execute all the builds generated.
 
     First, this function will create an instance of :py:class:`.BuildManifest` with the given metadata.
     Then it will install the build dependencies needed to compile the software.
     For all versions in the build manifest, a :py:class:`.Build` instance is
     created and executed (using :py:func:`stdlib.build.Build.build`).
-    At the end, all the retrieved packets are wrapped using :py:func:`stdlib.package.Package.wrap`.
+    At the end, all the retrieved packages are wrapped using :py:func:`stdlib.package.Package.wrap`.
 
     :info: The environment and current working directory is saved before each build, limiting the impact of one build on an other.
     :info: See the constructor of :py:class:`~stdlib.manifest.BuildManifest` and :py:class:`.BuildManifestMetadata`
@@ -195,7 +195,7 @@ def manifest(
     :info: The packages ``stable::raven-os/essentials`` and ``stable::raven-os/essentials-dev`` are guaranteed to be installed.
         There is no need to include them in ``build_dependencies``.
 
-    :param kwargs: Arguments transfered to the constructor of :py:class:`.BuildManifestMetadata`
+    :param kwargs: Arguments transferred to the constructor of :py:class:`.BuildManifestMetadata`
     :param versions_data: Versionized arguments of the build manifest.
     :param build_dependencies: A list of package requirements that must be installed (using ``nest``) before building anything.
     """

--- a/stdlib/package.py
+++ b/stdlib/package.py
@@ -13,7 +13,7 @@ from typing import List, Dict
 from termcolor import colored
 
 
-class PackageId():
+class PackageID():
     """The unique identifier of a package: its repository, category, name and version.
 
     :param name: The name of the package. The name should be in ``snake-case``.
@@ -106,7 +106,7 @@ class Package():
     """
     def __init__(
         self,
-        id: PackageId,
+        id: PackageID,
         description: str = None,
         tags: List[str] = None,
         maintainer: str = None,
@@ -139,7 +139,7 @@ class Package():
 
     def wrap(self):
         """Wrap the package by creating all the files needed by the repository (``nest-server``) to publish the package and putting
-        them in the path pointed by ``self.package_cache``
+        them in the path referred to by ``self.package_cache``
         """
         stdlib.log.slog(f"Wrapping {self.id} ({self.wrap_cache})")
 

--- a/stdlib/package.py
+++ b/stdlib/package.py
@@ -1,6 +1,198 @@
 #!/usr/bin/env python3.6
 # -*- coding: utf-8 -*-
+"""Types and functions to manipulate packages and their content."""
+
+import copy
+import os
+import shutil
+import tarfile
+import toml
+import datetime
+import stdlib.log
+from typing import List, Dict
+from termcolor import colored
+
+
+class PackageId():
+    """The unique identifier of a package: its repository, category, name and version.
+
+    :param name: The name of the package. The name should be in ``snake-case``.
+    :param repository: The name of the repository. The name should be in ``snake-case``.
+        If ``None`` is given, the repository name is taken from the arguments given to Nest Build.
+        The default value is ``None``.
+    :param category: The name of the category. The name should be in ``snake-case``.
+        If ``None`` is given, the category name is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param version: The version number. The version should follow `Semantic Versioning 2.0.0`_.
+        If ``None`` is given, the version number is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+
+    .. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
+    """
+    def __init__(
+        self,
+        name: str,
+        repository: str = None,
+        category: str = None,
+        version: str = None,
+    ):
+        build = stdlib.build.current_build()
+
+        import core.args
+        self.repository = repository if repository is not None else core.args.get_args().repository
+        self.category = category if category is not None else build.manifest.metadata.category
+        self.version = version if version is not None else build.semver
+        self.name = name
+
+    def full_name(self) -> str:
+        """Return a string representing the full name of the package, which is the combination of its repository, category and name.
+
+        :return: A string representing The full name of the package
+        """
+        return f'{self.repository}::{self.category}/{self.name}'
+
+    def __str__(self) -> str:
+        return f'{self.full_name()}#{self.version}'
 
 
 class Package():
-    pass
+    """A package, the output of a :py:class:`~stdlib.build.Build`.
+
+    :param id: The unique identifier of the package, including its name, category, repository and version.
+    :param description: A description of the package. This description should start with an uppercase letter and finish with a dot.
+        If ``None`` is given, the description is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param tags: A list of tags helping a user find the built packages easily. Each tag should be in ``snake-case``.
+        If ``None`` is given, the list of tags is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param maintainer: The email address of the maintainer of this build manifest.
+        If ``None`` is given, the maintainer's email address is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param licenses: The licenses of the built software.
+        If ``None`` is given, the licenses are taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param upstream_url: An URL pointing to the home page of the software.
+        If ``None`` is given, the url is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
+        The default value is ``None``.
+    :param run_dependencies: A dictionnary of runtime dependencies. The key is a package full name, and the value is a version requirement.
+        The default value is ``dict()``.
+
+    :ivar id: The unique identifier of the package, including its name, category, repository and version.
+    :vartype id: ``str``
+
+    :ivar description: A description of the package.
+    :vartype description: ``str``
+
+    :ivar tags: A list of tags helping a user find the built packages easily.
+    :vartype tags: ``List`` [ ``str`` ]
+
+    :ivar maintainer: The email address of the maintainer of this build manifest.
+    :vartype maintainer: ``str``
+
+    :ivar licenses: The licenses of the built software.
+    :vartype licenses: ``List`` [ :py:class:`~stdlib.license.License` ]
+
+    :ivar upstream_url: An URL pointing to the home page of the software.
+    :vartype upstream_url: ``str``
+
+    :ivar run_dependencies: A dictionnary of runtime dependencies. The key is a package full name, and the value is a version requirement.
+    :vartype run_dependencies: ``Dict`` [ ``str``, ``str`` ]
+
+    :ivar wrap_cache: The path pointing to the cache where the files that belong to this package should be placed before the package is wrapped.
+    :vartype wrap_cache: ``str``
+
+    :ivar package_cache: The path pointing to the folder where the resulting package is placed after being wrapped.
+    :vartype package_cache: ``str``
+    """
+    def __init__(
+        self,
+        id: PackageId,
+        description: str = None,
+        tags: List[str] = None,
+        maintainer: str = None,
+        licenses: List[stdlib.License] = None,
+        upstream_url: str = None,
+        run_dependencies: Dict[str, str] = dict(),
+    ):
+        from core.cache import get_wrap_cache, get_package_cache
+
+        build = stdlib.build.current_build()
+
+        self.id = id
+        self.description = description if description is not None else build.manifest.metadata.description
+        self.description = self.description.replace('\n', ' ').strip()
+        self.maintainer = maintainer if maintainer is not None else build.manifest.metadata.maintainer
+        self.licenses = licenses if licenses is not None else build.manifest.metadata.licenses
+        self.upstream_url = upstream_url if upstream_url is not None else build.manifest.metadata.upstream_url
+        self.run_dependencies = copy.deepcopy(run_dependencies)
+
+        self.wrap_cache = get_wrap_cache(self)
+        self.package_cache = get_package_cache(self)
+
+        if os.path.exists(self.wrap_cache):
+            shutil.rmtree(self.wrap_cache)
+        os.makedirs(self.wrap_cache)
+
+        if os.path.exists(self.package_cache):
+            shutil.rmtree(self.package_cache)
+        os.makedirs(self.package_cache)
+
+    def wrap(self):
+        """Wrap the package by creating all the files needed by the repository (``nest-server``) to publish the package and putting
+        them in the path pointed by ``self.package_cache``
+        """
+        stdlib.log.slog(f"Wrapping {self.id} ({self.wrap_cache})")
+
+        with stdlib.pushd(self.wrap_cache):
+            files_count = 0
+            stdlib.log.ilog("Files added:")
+            with stdlib.log.pushlog():
+                for root, _, filenames in os.walk('.'):
+                    for filename in filenames:
+                        stdlib.log.ilog(__colored_path(os.path.join(root, filename)))
+                        files_count += 1
+            stdlib.log.ilog(f"(That's {files_count} files.)")
+
+            stdlib.log.slog("Creating data.tar.gz")
+            tarball_path = os.path.join(self.package_cache, 'data.tar.gz')
+            with tarfile.open(tarball_path, mode='w:gz') as archive:
+                archive.add('./')
+
+        stdlib.log.slog("Creating manifest.toml")
+        toml_path = os.path.join(self.package_cache, 'manifest.toml')
+        with open(toml_path, "w") as filename:
+            manifest = {
+                'metadata': {
+                    'name': self.id.name,
+                    'category': self.id.category,
+                    'version': self.id.version,
+                    'description': self.description,
+                    'created_at': datetime.datetime.utcnow().replace(microsecond=0).isoformat() + 'Z',
+                },
+                'dependencies': self.run_dependencies,
+            }
+            toml.dump(manifest, filename)
+
+    def __str__(self):
+        return str(self.id)
+
+
+def __colored_path(path, pretty_path=None):
+    if pretty_path is None:
+        pretty_path = path
+
+    if os.path.islink(path):
+        target_path = os.path.join(
+            os.path.dirname(path),
+            os.readlink(path),
+        )
+        if os.path.exists(target_path):
+            return f"{colored(path, 'cyan', attrs=['bold'])} -> {__colored_path(target_path, os.readlink(path))}"
+        else:
+            return f"{colored(path, on_color='on_red', attrs=['bold'])} -> {colored(os.readlink(path), on_color='on_red', attrs=['bold'])}"
+    elif os.path.isdir(path):
+        return colored(pretty_path, 'blue', attrs=['bold'])
+    elif os.access(path, os.X_OK):
+        return colored(pretty_path, 'green', attrs=['bold'])
+    else:
+        return pretty_path

--- a/stdlib/package.py
+++ b/stdlib/package.py
@@ -47,7 +47,7 @@ class PackageId():
     def full_name(self) -> str:
         """Return a string representing the full name of the package, which is the combination of its repository, category and name.
 
-        :return: A string representing The full name of the package
+        :return: A string representing the full name of the package
         """
         return f'{self.repository}::{self.category}/{self.name}'
 
@@ -62,7 +62,7 @@ class Package():
     :param description: A description of the package. This description should start with an uppercase letter and finish with a dot.
         If ``None`` is given, the description is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
         The default value is ``None``.
-    :param tags: A list of tags helping a user find the built packages easily. Each tag should be in ``snake-case``.
+    :param tags: A list of tags helping a user to find the built packages easily. Each tag should be in ``snake-case``.
         If ``None`` is given, the list of tags is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
         The default value is ``None``.
     :param maintainer: The email address of the maintainer of this build manifest.
@@ -74,7 +74,7 @@ class Package():
     :param upstream_url: An URL pointing to the home page of the software.
         If ``None`` is given, the url is taken from the current :py:class:`~stdlib.manifest.BuildManifestMetadata`.
         The default value is ``None``.
-    :param run_dependencies: A dictionnary of runtime dependencies. The key is a package full name, and the value is a version requirement.
+    :param run_dependencies: A dictionary of runtime dependencies. The key is a package's full name, and the value is a version requirement.
         The default value is ``dict()``.
 
     :ivar id: The unique identifier of the package, including its name, category, repository and version.
@@ -83,7 +83,7 @@ class Package():
     :ivar description: A description of the package.
     :vartype description: ``str``
 
-    :ivar tags: A list of tags helping a user find the built packages easily.
+    :ivar tags: A list of tags helping a user to find the built packages easily.
     :vartype tags: ``List`` [ ``str`` ]
 
     :ivar maintainer: The email address of the maintainer of this build manifest.
@@ -95,7 +95,7 @@ class Package():
     :ivar upstream_url: An URL pointing to the home page of the software.
     :vartype upstream_url: ``str``
 
-    :ivar run_dependencies: A dictionnary of runtime dependencies. The key is a package full name, and the value is a version requirement.
+    :ivar run_dependencies: A dictionary of runtime dependencies. The key is a package's full name, and the value is a version requirement.
     :vartype run_dependencies: ``Dict`` [ ``str``, ``str`` ]
 
     :ivar wrap_cache: The path pointing to the cache where the files that belong to this package should be placed before the package is wrapped.

--- a/stdlib/pushd.py
+++ b/stdlib/pushd.py
@@ -7,9 +7,10 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def pushd(path: str):
+def pushd(path: str = '.'):
     """Save the current working directory and switch to the given one for the duration of the new context.
 
+    :info: A default value of `path` is provided, pointing to the current working directory (`.`).
     :param path: The new current working directory.
     """
     old_path = os.getcwd()


### PR DESCRIPTION
This PR also slightly modifies the documentation of older functions to make them more consistent with the new ones.