### PR TITLE
Remove the version component of the package cache

### DIFF
--- a/core/cache.py
+++ b/core/cache.py
@@ -88,18 +88,17 @@ def get_package_cache(package) -> str:
 
     This cache is populated automatically at the end of the build process. A build manifest should not have to write anything to it.
 
-    :info: This cache is populated by Package.wrap() and contains the manifest and data of the package
+    :info: This cache is populated by Package.wrap() and contains the NPF representing the package
     :param package: The package associated with the cache
     :type package: :py:class:`.Package`
 
-    :returns: The path pointing to the cache where the files belonging to the given package should be stored
+    :returns: The path pointing to the cache where the NPF representing given package should be stored
     """
     return os.path.join(
         core.args.get_args().output_dir,
         package.id.repository,
         package.id.category,
         package.id.name,
-        package.id.version,
     )
 
 

--- a/stdlib/package.py
+++ b/stdlib/package.py
@@ -153,7 +153,7 @@ class Package():
         os.makedirs(self.wrap_cache)
 
         if not os.path.exists(self.package_cache):
-        os.makedirs(self.package_cache)
+            os.makedirs(self.package_cache)
 
     def is_empty(self) -> bool:
         """Test whether the ``wrap_cache`` of this :py:class:`.Package` contains at least a single file.

--- a/stdlib/package.py
+++ b/stdlib/package.py
@@ -152,8 +152,7 @@ class Package():
             shutil.rmtree(self.wrap_cache)
         os.makedirs(self.wrap_cache)
 
-        if os.path.exists(self.package_cache):
-            shutil.rmtree(self.package_cache)
+        if not os.path.exists(self.package_cache):
         os.makedirs(self.package_cache)
 
     def is_empty(self) -> bool:
@@ -386,7 +385,7 @@ class Package():
             }
             toml.dump(manifest, filename)
 
-        stdlib.log.slog("Creating package.nest")
+        stdlib.log.slog(f"Creating {self.id.name}-{self.id.version}.nest")
         with stdlib.pushd(self.package_cache):
             nest_file = os.path.join(self.package_cache, f'{self.id.name}-{self.id.version}.nest')
             with tarfile.open(nest_file, mode='w') as archive:


### PR DESCRIPTION
This decision is motivated by the (new) fact that NPF are named `name-version.nest`, and therefore cannot collide with each other.