### PR TITLE
Remove --{host,build,target} from ./configure

### DIFF
--- a/stdlib/template/configure.py
+++ b/stdlib/template/configure.py
@@ -113,10 +113,6 @@ def configure(
     # Call the configure script
     stdlib.cmd(f''' \
         {binary} \
-            --host="{os.environ['TARGET']}" \
-            --build="{os.environ['TARGET']}" \
-            --target="{os.environ['TARGET']}" \
-            \
             --enable-stack-protector=all \
             --enable-stackguard-randomization \
             \


### PR DESCRIPTION
This caused some files being generated to have the target as prefix, i.e. `x86_64-raven-linux-gnu-htop` instead of `htop`