### PR TITLE
Fix log flushing when stdout is redirected

### DIFF
--- a/stdlib/log.py
+++ b/stdlib/log.py
@@ -31,7 +31,7 @@ def dlog(*logs: str):
     global log_tab_level
 
     indent = '    ' * log_tab_level
-    print(f"{termcolor.colored('[d]', 'magenta', attrs=['bold'])} {indent}", *logs)
+    print(f"{termcolor.colored('[d]', 'magenta', attrs=['bold'])} {indent}", *logs, flush=True)
 
 
 def ilog(*logs: str):
@@ -42,7 +42,7 @@ def ilog(*logs: str):
     global log_tab_level
 
     indent = '    ' * log_tab_level
-    print(f"{termcolor.colored('[*]', 'blue', attrs=['bold'])} {indent}", *logs)
+    print(f"{termcolor.colored('[*]', 'blue', attrs=['bold'])} {indent}", *logs, flush=True)
 
 
 def slog(*logs: str):
@@ -53,7 +53,7 @@ def slog(*logs: str):
     global log_tab_level
 
     indent = '    ' * log_tab_level
-    print(f"{termcolor.colored('[+]', 'green', attrs=['bold'])} {indent}", *logs)
+    print(f"{termcolor.colored('[+]', 'green', attrs=['bold'])} {indent}", *logs, flush=True)
 
 
 def wlog(*logs: str):
@@ -64,7 +64,7 @@ def wlog(*logs: str):
     global log_tab_level
 
     indent = '    ' * log_tab_level
-    print(f"{termcolor.colored('[!]', 'yellow', attrs=['bold'])} {indent}", *logs)
+    print(f"{termcolor.colored('[!]', 'yellow', attrs=['bold'])} {indent}", *logs, flush=True)
 
 
 def elog(*logs: str):
@@ -75,7 +75,7 @@ def elog(*logs: str):
     global log_tab_level
 
     indent = '    ' * log_tab_level
-    print(f"{termcolor.colored('[-]', 'red', attrs=['bold'])} {indent}", *logs)
+    print(f"{termcolor.colored('[-]', 'red', attrs=['bold'])} {indent}", *logs, flush=True)
 
 
 def flog(*logs: str):


### PR DESCRIPTION
According to the documentation https://docs.python.org/3/library/sys.html#sys.stdout

> When interactive, stdout and stderr streams are line-buffered. Otherwise, they are block-buffered like regular text files. You can override this value with the -u command-line option.

So if we want to redirect the output (`./nbuild.py -vvv readline.py > log`) the logs will be printed at the end of the compilation except if we force the `print` function to flush or call python with `-u` unbuffered option.